### PR TITLE
Adjusted HSDatepicker implementation

### DIFF
--- a/frontend/src/components/SharedComponents/Input/HSDatepicker.vue
+++ b/frontend/src/components/SharedComponents/Input/HSDatepicker.vue
@@ -1,19 +1,14 @@
 <template>
     <div class="mb-3">
         <label class="form-label">{{ label }}</label>
-        <input
-            @change="onChange"
-            type="date"
-            class="form-control"
-            :value="formattedDate.format(Utilities.dateFormat)"
-        />
+        <input @change="onChange" type="date" class="form-control" :value="formattedDate ?? ''" />
     </div>
 </template>
 
 <script setup lang="ts">
 import { Utilities } from "@/Utilities";
 import moment from "moment";
-import { ref, watch } from "vue";
+import { computed} from "vue";
 
 interface Props {
     label: string;
@@ -22,19 +17,18 @@ interface Props {
 
 const props = defineProps<Props>();
 const emit = defineEmits(["update:modelValue"]);
-const formattedDate = ref(moment(props.modelValue));
-
-watch(
-    () => props.modelValue,
-    (newDate) => {
-        formattedDate.value = moment(newDate);
+const formattedDate = computed<string | null>(() => {
+    if (props.modelValue && props.modelValue.length > 0) {
+        return moment(props.modelValue).format(Utilities.dateFormat);
     }
-);
+
+    return null;
+});
 
 function onChange(event: Event) {
     const element = event.target as HTMLInputElement;
-    formattedDate.value = moment(element.value);
-    emit("update:modelValue", formattedDate.value.format(Utilities.dateFormat));
+    const value = element.value.length > 0 ? element.value : undefined;
+    emit("update:modelValue", value);
 }
 </script>
 


### PR DESCRIPTION
Adjusted how HSDatepicker handles dates.
- Empty string wasn't accounted for in moment conversion, and returned "Invalid Date" as a string to backend