### PR TITLE
Remove categories before product deletion

### DIFF
--- a/HomeStorage.Logic/Logic/ProductLogic.cs
+++ b/HomeStorage.Logic/Logic/ProductLogic.cs
@@ -145,11 +145,13 @@ namespace HomeStorage.Logic.Logic
                 return null;
 
             Product? product = await _db.Products
+                .Include(x => x.Categories)
                 .FirstOrDefaultAsync(x => x.ProductId == productId);
 
             if (product is null)
                 return null;
 
+            product.Categories.Clear();
             _db.Products.Remove(product);
 
             await _db.SaveChangesAsync();


### PR DESCRIPTION
Products couldn't be deleted while they had categories attached.
- Clears categories from the product before total deletion
     - Gave error because it was referenced in mapping table between categories and the product